### PR TITLE
Fix favicon upload/display and sitemap visibility/route issues

### DIFF
--- a/export/config/statamic/assets.php
+++ b/export/config/statamic/assets.php
@@ -86,6 +86,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Additional Uploadable Extensions
+    |--------------------------------------------------------------------------
+    |
+    | Statamic will only allow uploads of certain approved file extensions.
+    | If you need to allow more file extensions, you may add them here.
+    |
+    */
+
+    'additional_uploadable_extensions' => [
+        'ico',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Auto-Crop Assets
     |--------------------------------------------------------------------------
     |

--- a/export/content/collections/pages/home.md
+++ b/export/content/collections/pages/home.md
@@ -10,7 +10,7 @@ seo_meta_description: empty
 seo_canonical: none
 seo_og_title: title
 seo_og_description: custom
-seo_custom_og_desc: asasdasdad
+seo_custom_og_desc: statamic starter
 seo_tw_title: title
 seo_tw_description: general
 builder:

--- a/export/resources/views/partials/_favicons.antlers.html
+++ b/export/resources/views/partials/_favicons.antlers.html
@@ -1,4 +1,13 @@
-<link rel="apple-touch-icon" sizes="180x180" href="{{ theme:favicon_180 }}">
-<link rel="icon" type="image/png" sizes="32x32" href="{{ theme:favicon_32 }}">
-<link rel="icon" type="image/png" sizes="16x16" href="{{ theme:favicon_16 }}">
+{{ if theme:favicon }}
+    <link rel="icon" type="image/x-icon" href="{{ theme:favicon }}">
+{{ /if }}
+{{ if theme:favicon_180 }}
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ theme:favicon_180 }}">
+{{ /if }}
+{{ if theme:favicon_32 }}
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ theme:favicon_32 }}">
+{{ /if }}
+{{ if theme:favicon_16 }}
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ theme:favicon_16 }}">
+{{ /if }}
 <link rel="manifest" href="/site.webmanifest">

--- a/export/resources/views/partials/_sitemap.antlers.html
+++ b/export/resources/views/partials/_sitemap.antlers.html
@@ -4,18 +4,11 @@
         {{ collection from="{handle}" as="results" }}
             {{ results }}
                 <url>
-                    <loc>
-                        {{ permalink }}
-                    </loc>
-                    <lastmod>
-                        {{ updated_at format="Y-m-d" }}
-                    </lastmod>
-                    <changefreq>
-                        {{ seo:sitemap_change_frequency ? seo:sitemap_change_frequency : 'weekly' }}
+                    <loc>{{ permalink }}</loc>
+                    <lastmod>{{ updated_at format="Y-m-d" }}</lastmod>
+                    <changefreq>{{ seo:sitemap_change_frequency ? seo:sitemap_change_frequency : 'weekly' }}
                     </changefreq>
-                    <priority>
-                        {{ seo:sitemap_priority ? seo:sitemap_priority : '0.5' }}
-                    </priority>
+                    <priority>{{ seo:sitemap_priority ? seo:sitemap_priority : '0.5' }}</priority>
                 </url>
             {{ /results }}
         {{ /collection }}

--- a/export/resources/views/partials/_sitemap.antlers.html
+++ b/export/resources/views/partials/_sitemap.antlers.html
@@ -11,10 +11,10 @@
                         {{ updated_at format="Y-m-d" }}
                     </lastmod>
                     <changefreq>
-                        {{ theme:sitemap_change_frequency ? theme:sitemap_change_frequency : 'weekly' }}
+                        {{ seo:sitemap_change_frequency ? seo:sitemap_change_frequency : 'weekly' }}
                     </changefreq>
                     <priority>
-                        {{ theme:sitemap_priority ? theme:sitemap_priority : '0.5' }}
+                        {{ seo:sitemap_priority ? seo:sitemap_priority : '0.5' }}
                     </priority>
                 </url>
             {{ /results }}

--- a/export/routes/web.php
+++ b/export/routes/web.php
@@ -15,7 +15,8 @@ use App\Http\Controllers\DynamicToken;
 */
 
 Route::statamic('/sitemap.xml', 'partials._sitemap', [
-    'layout' => null
+    'layout' => null,
+    'content_type' => 'application/xml',
 ]);
 
 Route::get('/!/token/refresh', DynamicToken::class);


### PR DESCRIPTION
Closes #41

## Overview

This PR includes the following changes:

- Added `.ico` format to `additional_uploadable_extensions` in `assets.php`  
- Updated `seo_custom_og_description` content  
- Added favicon support in `partials/_favicons`  
- Implemented checks for existing and non-existing favicons  
- Fixed the sitemap partial to loop and display data correctly:  
  - Now loops through `seo` instead of `theme`  
  - Added `content_type` to the sitemap route  

---

## For reviewers

The easiest way to test this is by following these steps:

1. Create a new Statamic site using the **statamic-starter**
2. After installation, copy and paste the changes from this branch into the appropriate files
3. Check the favicon and sitemap functionality for any potential bugs or errors
