### PR TITLE
Fix canonical tag to resolve from Entry

### DIFF
--- a/export/app/Tags/LuckySeo.php
+++ b/export/app/Tags/LuckySeo.php
@@ -3,6 +3,9 @@
 namespace App\Tags;
 
 use Statamic\Tags\Tags;
+use Statamic\Facades\Entry;
+
+
 
 class LuckySeo extends Tags
 {
@@ -51,7 +54,7 @@ class LuckySeo extends Tags
             return $this->context->get('seo_custom_meta_description');
         }
 
-         return null;
+        return null;
     }
 
     /**
@@ -61,7 +64,32 @@ class LuckySeo extends Tags
      */
     public function canonical()
     {
-        return $this->context->raw('seo_canonical') ?  $this->context->get('seo_canonical') : $this->context->get('permalink');
+        $value = $this->context->get('seo_canonical');
+
+        $resolved = $value->value();
+
+        if (is_string($resolved) && !empty($resolved)) {
+            return $resolved;
+        }
+
+        if ($resolved instanceof \Statamic\Fieldtypes\Link\ArrayableLink) {
+            $entry = $resolved->value();
+
+            if ($entry instanceof \Statamic\Entries\Entry) {
+                return $entry->absoluteUrl();
+            }
+
+            if (is_string($entry)) {
+                return $entry;
+            }
+        }
+
+        // Case 3: direct Entry reference
+        if ($resolved instanceof \Statamic\Entries\Entry) {
+            return $resolved->absoluteUrl();
+        }
+
+        return $this->context->get('permalink');
     }
 
     /**
@@ -160,3 +188,4 @@ class LuckySeo extends Tags
         }
     }
 }
+

--- a/export/app/Tags/LuckySeo.php
+++ b/export/app/Tags/LuckySeo.php
@@ -23,12 +23,8 @@ class LuckySeo extends Tags
             $title = $this->context->get('seo_custom_meta_title');
         }
 
-        if ($append) {
-            return "$title - $append";
-        }
-
-        if($prepend) {
-            return "$prepend - $title";
+        if ($append || $prepend) {
+            return ($prepend ? "$prepend - " : '') . "$title" . ($append ? " - $append" : '');
         }
 
         return $title;

--- a/export/app/Tags/LuckySeo.php
+++ b/export/app/Tags/LuckySeo.php
@@ -145,9 +145,9 @@ class LuckySeo extends Tags
      *
      * @return string|array
      */
-    public function twDescription()
+        public function twDescription()
     {
-        $desc_config = $this->context->raw('seo_og_description');
+        $desc_config = $this->context->raw('seo_tw_description');
 
         if ($desc_config === 'meta') {
             return $this->description();
@@ -159,7 +159,7 @@ class LuckySeo extends Tags
         }
 
         if($desc_config === 'custom') {
-            return $this->context->get('seo_custom_og_desc');
+            return $this->context->get('seo_custom_tw_desc');
         }
 
         return null;

--- a/export/app/Tags/LuckySeo.php
+++ b/export/app/Tags/LuckySeo.php
@@ -3,9 +3,6 @@
 namespace App\Tags;
 
 use Statamic\Tags\Tags;
-use Statamic\Facades\Entry;
-
-
 
 class LuckySeo extends Tags
 {
@@ -145,7 +142,7 @@ class LuckySeo extends Tags
      *
      * @return string|array
      */
-        public function twDescription()
+    public function twDescription()
     {
         $desc_config = $this->context->raw('seo_tw_description');
 
@@ -179,4 +176,3 @@ class LuckySeo extends Tags
         }
     }
 }
-

--- a/export/app/Tags/LuckySeo.php
+++ b/export/app/Tags/LuckySeo.php
@@ -68,10 +68,6 @@ class LuckySeo extends Tags
 
         $resolved = $value->value();
 
-        if (is_string($resolved) && !empty($resolved)) {
-            return $resolved;
-        }
-
         if ($resolved instanceof \Statamic\Fieldtypes\Link\ArrayableLink) {
             $entry = $resolved->value();
 
@@ -82,11 +78,6 @@ class LuckySeo extends Tags
             if (is_string($entry)) {
                 return $entry;
             }
-        }
-
-        // Case 3: direct Entry reference
-        if ($resolved instanceof \Statamic\Entries\Entry) {
-            return $resolved->absoluteUrl();
         }
 
         return $this->context->get('permalink');

--- a/export/app/Tags/LuckySeo.php
+++ b/export/app/Tags/LuckySeo.php
@@ -59,7 +59,7 @@ class LuckySeo extends Tags
     {
         $value = $this->context->get('seo_canonical');
 
-        $resolved = $value->value();
+        $resolved = $value?->value();
 
         if ($resolved instanceof \Statamic\Fieldtypes\Link\ArrayableLink) {
             $entry = $resolved->value();


### PR DESCRIPTION
closes #46 

### **Overview**

This PR updates the LuckySeo.php Tag to ensure the canonical URL is generated correctly. Instead of returning relative paths, it now outputs the full absolute canonical URL, improving SEO consistency and ensuring external crawlers interpret the correct domain.

UPDATE:
- Also a small fix for tw-description and custom-tw-description
- Fixed Append/Prepend to be visible if both available.

For Reviewers:

install a fresh statamic project with the starter kit

```
statamic new statamic-starter lucky-media/statamic-starter
```

copy-paste the LuckySeo.php code from this branch.

Open or Create a new Page (e.g., Home, About) and verify the canonical URL:

- When seo_canonical is an Entry → should return absolute URL for that Entry.
- When seo_canonical is a string → should return the string (e.g https://www.testing.com/).
- When empty → should fallback to the page’s permalink.